### PR TITLE
Split the upload into batches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,9 @@ jobs:
           - name: opi5pro
             script: ./install_opi5.sh
             base_image: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v2.3.0/ubuntu-24.04-preinstalled-server-arm64-orangepi-5-pro.img.xz
+          - name: opi5max
+            script: ./install_opi5.sh
+            base_image: https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v2.3.1/ubuntu-24.04-preinstalled-server-arm64-orangepi-5-max.img.xz
 
     name: "Build for ${{ matrix.name }}"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,14 @@ jobs:
       - uses: softprops/action-gh-release@v2.0.8
         with:
           files: |
-            **/*.xz
+            **/*opi5*.xz
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: softprops/action-gh-release@v2.0.8
+        with:
+          files: |
+            !**/*opi5*.xz
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This works around a problem where softprops/action-gh-releases fails when uploading too many large files at the same time. https://github.com/softprops/action-gh-release/issues/353